### PR TITLE
add Message column width property as Dependency Property and LogName

### DIFF
--- a/src/NLogViewer.TestApp/MainWindow.xaml
+++ b/src/NLogViewer.TestApp/MainWindow.xaml
@@ -6,6 +6,6 @@
         xmlns:dj="clr-namespace:DJ;assembly=NLogViewer"
         mc:Ignorable="d" Height="450" Width="800">
     <Grid>
-        <dj:NLogViewer MaxCount="1000"/>
+        <dj:NLogViewer MaxCount="1000" MessageWidth="376"/>
     </Grid>
 </Window>

--- a/src/NLogViewer/NLogViewer.xaml
+++ b/src/NLogViewer/NLogViewer.xaml
@@ -160,8 +160,12 @@
                 <GridViewColumn Header="TimeStamp"
                                 DisplayMemberBinding="{Binding Path=TimeStamp, StringFormat=\{0:dd-MM-yyyy hh:mm:ss.fff \}}" 
                                 Width="Auto"/>
-                <GridViewColumn Header="LoggerName" DisplayMemberBinding="{Binding Path=LoggerName}" Width="Auto"/>
-                <GridViewColumn Header="Message" Width="Auto">
+                <GridViewColumn Header="LoggerName" DisplayMemberBinding="{Binding Path=LoggerName}"
+                                Width="{Binding Path=LoggerNameWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type dj:NLogViewer}}}"
+                                />
+                <GridViewColumn Header="Message"
+                                Width="{Binding Path=MessageWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type dj:NLogViewer}}}"
+                                >
                     <GridViewColumn.CellTemplate>
                         <DataTemplate>
                             <TextBox

--- a/src/NLogViewer/NLogViewer.xaml.cs
+++ b/src/NLogViewer/NLogViewer.xaml.cs
@@ -323,7 +323,33 @@ namespace DJ
         /// The <see cref="MaxCount"/> DependencyProperty.
         /// </summary>
         public static readonly DependencyProperty MaxCountProperty = DependencyProperty.Register("MaxCount", typeof(int), typeof(NLogViewer), new PropertyMetadata(5000));
-        
+
+        [Category("NLogViewer"),Description("Set Message column width"),DefaultValue(Double.NaN)]
+        public double MessageWidth
+        {
+            get => (double)GetValue(MessageWidthProperty);
+            set => SetValue(MessageWidthProperty, value);
+        }
+
+        /// <summary>
+        /// The <see cref="MessageWidth"/> DependencyProperty.
+        /// </summary>
+        public static readonly DependencyProperty MessageWidthProperty = DependencyProperty.Register("MessageWidth",
+            typeof(double), typeof(NLogViewer), new UIPropertyMetadata(Double.NaN));
+
+        [Category("NLogViewer"), Description("Set LoggerName column width"), DefaultValue(Double.NaN)]
+        public double LoggerNameWidth
+        {
+            get => (double)GetValue(LoggerNameWidthProperty);
+            set => SetValue(LoggerNameWidthProperty, value);
+        }
+
+        /// <summary>
+        /// The <see cref="LoggerNameWidth"/> DependencyProperty.
+        /// </summary>
+        public static readonly DependencyProperty LoggerNameWidthProperty = DependencyProperty.Register("LoggerNameWidth",
+            typeof(double), typeof(NLogViewer), new UIPropertyMetadata(Double.NaN));
+
         #endregion
 
         // ##############################################################################################################################


### PR DESCRIPTION
In the Message column, If the message is long, characters cannot be seen.

I would like to fill Message column width to edge automatically from start.
Or I would like to set Message column width externally.

I added Message column width ( and LogName column width) as DependencyProperty.

If you can fill Message column width to edge other ways, that's fine.
